### PR TITLE
feat: implement dynamic browser API endpoints

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -7,157 +7,215 @@ const { runMapa } = require('./navegar');
 const app = express();
 app.use(express.json());
 
-// --- Carrega todos os mapas na pasta src/mapas ---
+// --- Carrega mapas dinamicamente -----------------------------------------
 const MAP_DIR = path.join(__dirname, 'mapas');
+// Estrutura: { operacao: { categoria: mapa } }
 const mapas = {};
 
 function loadMapas() {
-  const files = fs.existsSync(MAP_DIR) ? fs.readdirSync(MAP_DIR) : [];
-  files.forEach(file => {
-    const m = file.match(/^mapa_(.+)\.json$/);
-    if (!m) return;
-    const name = m[1]; // ex.: "consulta", "inserirMotorista", "baixarPdf"
-    const fullPath = path.join(MAP_DIR, file);
-    try {
-      const content = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
-      mapas[name] = content;
-    } catch (e) {
-      console.error(`Falha ao carregar mapa ${file}:`, e.message);
+  if (!fs.existsSync(MAP_DIR)) return;
+
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      const stat = fs.statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!entry.endsWith('.json')) continue;
+      try {
+        const json = JSON.parse(fs.readFileSync(full, 'utf8'));
+        const { operacao, categoria } = json;
+        if (!operacao || !categoria) {
+          console.warn(`Mapa sem operacao/categoria ignorado: ${full}`);
+          continue;
+        }
+        const op = operacao.toLowerCase();
+        const cat = categoria.toLowerCase();
+        if (!mapas[op]) mapas[op] = {};
+        mapas[op][cat] = json;
+      } catch (e) {
+        console.error(`Falha ao carregar mapa ${full}:`, e.message);
+      }
     }
-  });
+  };
+
+  walk(MAP_DIR);
 }
+
 loadMapas();
 
-// --- Util: extrai as "keys" exigidas pelos steps do mapa (fill/upload/select) ---
-function getRequiredKeys(mapa) {
-  const set = new Set();
-  if (!mapa || !Array.isArray(mapa.steps)) return set;
-  for (const s of mapa.steps) {
-    if (!s || !s.action) continue;
-    if ((s.action === 'fill' || s.action === 'upload' || s.action === 'select') && s.key) {
-      set.add(s.key);
+// --- Utilitários ----------------------------------------------------------
+function getStepKeys(mapa) {
+  const keys = new Set();
+  if (mapa && Array.isArray(mapa.steps)) {
+    for (const s of mapa.steps) {
+      if (['fill', 'upload', 'select'].includes(s.action) && s.key) {
+        keys.add(s.key);
+      }
     }
   }
-  return set;
+  return Array.from(keys);
 }
 
-// Utilitário: compõe loginInfo a partir dos headers quando necessário
-function buildLoginInfo(req, mapa) {
-  if (!mapa || !mapa.login) return undefined; // mapa sem login não precisa
+function buildLoginInfo(req) {
   const usernameValue = req.header('login');
   const passwordValue = req.header('password');
   if (!usernameValue || !passwordValue) {
-    throw new Error('Headers "login" e "password" são obrigatórios para este mapa.');
+    throw new Error('Headers "login" e "password" são obrigatórios.');
   }
   return { usernameValue, passwordValue };
 }
 
-// Handler compartilhado para GET (com ou sem :value)
-async function handleGet(req, res) {
-  const { operation, value } = req.params;
-  const mapa = mapas[operation];
-  if (!mapa) return res.status(404).json({ error: `Mapa "${operation}" não encontrado.` });
-
-  const url = req.query.url;
-  if (!url) return res.status(400).json({ error: 'Query param "url" é obrigatório.' });
-
-  // Regras novas: mapa GET tem 0 ou 1 key. Se 0 → sem :value; se 1 → :value é o valor dessa key.
-  const requiredKeys = getRequiredKeys(mapa);
-  if (requiredKeys.size > 1) {
-    return res.status(400).json({ error: 'Mapa inválido para GET: mais de uma key encontrada nos steps.' });
+function validateKeys(required, provided, { allowPartial = false } = {}) {
+  const invalid = provided.filter((k) => !required.includes(k));
+  if (invalid.length) {
+    throw new Error(`Chaves inválidas: ${invalid.join(', ')}`);
   }
-
-  let dados = {};
-  if (requiredKeys.size === 0) {
-    // Não deve haver segundo path param
-    if (typeof value !== 'undefined') {
-      return res.status(400).json({ error: 'Rota inválida: este mapa não aceita valor no path.' });
+  if (!allowPartial) {
+    const missing = required.filter((k) => !provided.includes(k));
+    if (missing.length) {
+      throw new Error(`Chaves ausentes: ${missing.join(', ')}`);
     }
-    // dados permanece vazio
-  } else {
-    // Exatamente 1 key → exige :value
-    const singleKey = [...requiredKeys][0];
-    if (typeof value === 'undefined' || value === '') {
-      return res.status(400).json({ error: `Rota inválida: este mapa exige um valor no path para a key "${singleKey}".` });
-    }
-    dados = { [singleKey]: value };
-  }
-
-  // options: ainda aceito ?downloadDir=... (opcional) para mapas de download
-  const options = {};
-  if (req.query.downloadDir) options.downloadDir = req.query.downloadDir;
-
-  let loginInfo;
-  try {
-    loginInfo = buildLoginInfo(req, mapa);
-  } catch (e) {
-    return res.status(400).json({ error: e.message });
-  }
-
-  try {
-    const { resultFound, downloadedPath } = await runMapa({ url, loginInfo, dados, mapa, options });
-
-    // Respostas conforme o modo do mapa
-    if (mapa.modo === 'download') {
-      return res.json({ downloadedPath: downloadedPath || null });
-    }
-    if (mapa.modo === 'consultar') {
-      return res.json({ result: !!resultFound });
-    }
-    if (mapa.modo === 'inserir') {
-      // GET para inserir não é o comum, mas se rodar, considera sucesso se não lançou erro
-      return res.json({ ok: true });
-    }
-    // Sem modo definido: devolve o que temos
-    return res.json({ result: !!resultFound, downloadedPath: downloadedPath || null });
-  } catch (err) {
-    return res.status(500).json({ error: err.message });
   }
 }
 
-// --- GET rotas (sem parâmetro opcional no padrão) ---
-// Se o mapa tem 1 key → use /:operation/:value
-app.get('/:operation/:value', handleGet);
-// Se o mapa tem 0 keys → use /:operation
-app.get('/:operation', handleGet);
+function getMapa(op, cat) {
+  return mapas[op] && mapas[op][cat];
+}
 
-// --- POST dinâmico: /:operation ---
-// Ex.: POST /inserirMotorista?url=http://...  (headers login/password, body { dados: {...} })
-//      POST /baixarPdf?url=http://...         (retorna { downloadedPath })
-app.post('/:operation', async (req, res) => {
-  const { operation } = req.params;
-  const mapa = mapas[operation];
-  if (!mapa) return res.status(404).json({ error: `Mapa "${operation}" não encontrado.` });
+// --- CONSULTAR -----------------------------------------------------------
+app.get('/consultar/:categoria', async (req, res) => {
+  const op = 'consultar';
+  const cat = req.params.categoria.toLowerCase();
+  const mapa = getMapa(op, cat);
+  if (!mapa) return res.status(404).json({ error: `Mapa "${op}/${cat}" não encontrado.` });
 
   const url = req.query.url;
   if (!url) return res.status(400).json({ error: 'Query param "url" é obrigatório.' });
 
   let loginInfo;
-  try {
-    loginInfo = buildLoginInfo(req, mapa);
-  } catch (e) {
+  try { loginInfo = buildLoginInfo(req); } catch (e) {
     return res.status(400).json({ error: e.message });
   }
 
-  const bodyDados = (req.body && req.body.dados) ? req.body.dados : (req.body || {});
-  const options = {};
-  if (req.query.downloadDir) options.downloadDir = req.query.downloadDir;
+  const required = getStepKeys(mapa);
+  const queryKeys = Object.keys(req.query).filter((k) => k !== 'url');
+  try { validateKeys(required, queryKeys); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const dados = {};
+  queryKeys.forEach((k) => { dados[k] = req.query[k]; });
 
   try {
-    const { resultFound, downloadedPath } = await runMapa({ url, loginInfo, dados: bodyDados, mapa, options });
+    const { resultFound } = await runMapa({ url, loginInfo, dados, mapa });
+    return res.json({ result: !!resultFound });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
 
-    // Respostas conforme o modo do mapa
-    if (mapa.modo === 'download') {
-      return res.json({ downloadedPath: downloadedPath || null });
-    }
-    if (mapa.modo === 'inserir') {
-      return res.json({ ok: true });
-    }
-    if (mapa.modo === 'consultar') {
-      return res.json({ result: !!resultFound });
-    }
-    // Sem modo definido: devolve o que temos
-    return res.json({ result: !!resultFound, downloadedPath: downloadedPath || null });
+// --- BAIXAR --------------------------------------------------------------
+app.get('/baixar/:categoria', async (req, res) => {
+  const op = 'baixar';
+  const cat = req.params.categoria.toLowerCase();
+  const mapa = getMapa(op, cat);
+  if (!mapa) return res.status(404).json({ error: `Mapa "${op}/${cat}" não encontrado.` });
+
+  const url = req.query.url;
+  if (!url) return res.status(400).json({ error: 'Query param "url" é obrigatório.' });
+
+  let loginInfo;
+  try { loginInfo = buildLoginInfo(req); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const required = getStepKeys(mapa);
+  const queryKeys = Object.keys(req.query).filter((k) => !['url', 'dir', 'filename'].includes(k));
+  try { validateKeys(required, queryKeys); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const dados = {};
+  queryKeys.forEach((k) => { dados[k] = req.query[k]; });
+
+  const options = {};
+  if (req.query.dir) options.downloadDir = req.query.dir;
+  options.filename = req.query.filename || `${op}_${cat}_${Math.random().toString(36).slice(2, 8)}`;
+
+  try {
+    const { downloadedPath } = await runMapa({ url, loginInfo, dados, mapa, options });
+    return res.json({ downloadedPath: downloadedPath || null });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- CADASTRAR -----------------------------------------------------------
+app.post('/cadastrar/:categoria', async (req, res) => {
+  const op = 'cadastrar';
+  const cat = req.params.categoria.toLowerCase();
+  const mapa = getMapa(op, cat);
+  if (!mapa) return res.status(404).json({ error: `Mapa "${op}/${cat}" não encontrado.` });
+
+  const url = req.query.url;
+  if (!url) return res.status(400).json({ error: 'Query param "url" é obrigatório.' });
+
+  let loginInfo;
+  try { loginInfo = buildLoginInfo(req); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const required = getStepKeys(mapa);
+  const bodyKeys = Object.keys(req.body || {});
+  try { validateKeys(required, bodyKeys); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const dados = req.body || {};
+
+  try {
+    await runMapa({ url, loginInfo, dados, mapa });
+    return res.json({ ok: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// --- EDITAR --------------------------------------------------------------
+app.patch('/editar/:categoria', async (req, res) => {
+  const op = 'editar';
+  const cat = req.params.categoria.toLowerCase();
+  const mapa = getMapa(op, cat);
+  if (!mapa) return res.status(404).json({ error: `Mapa "${op}/${cat}" não encontrado.` });
+
+  const url = req.query.url;
+  if (!url) return res.status(400).json({ error: 'Query param "url" é obrigatório.' });
+
+  let loginInfo;
+  try { loginInfo = buildLoginInfo(req); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const required = getStepKeys(mapa);
+  const queryKeys = Object.keys(req.query).filter((k) => k !== 'url');
+  const bodyKeys = Object.keys(req.body || {});
+  try { validateKeys(required, queryKeys, { allowPartial: true }); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+  try { validateKeys(required, bodyKeys, { allowPartial: true }); } catch (e) {
+    return res.status(400).json({ error: e.message });
+  }
+
+  const dados = {};
+  queryKeys.forEach((k) => { dados[k] = req.query[k]; });
+  bodyKeys.forEach((k) => { dados[k] = req.body[k]; });
+
+  try {
+    await runMapa({ url, loginInfo, dados, mapa });
+    return res.json({ ok: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }
@@ -166,3 +224,6 @@ app.post('/:operation', async (req, res) => {
 app.listen(3001, () => {
   console.log('API rodando em http://localhost:3001');
 });
+
+module.exports = { app, mapas };
+


### PR DESCRIPTION
## Summary
- load browser automation maps by operation and category
- expose consultar, baixar, cadastrar and editar endpoints with key validation
- support partial updates and custom download filenames in navigator

## Testing
- `npm test`
- `timeout 1 node src/server.js`


------
https://chatgpt.com/codex/tasks/task_e_6893901f2a448327a8efa8001177a5c5