### PR TITLE
docs: atualiza README com endpoints da API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,94 @@
-
----
-
-## 📗 `README-executor.md`
-
-```markdown
 # Contilogg Executor Playwright API
 
-API Express que consome “mapas” JSON gerados pelo Mapeador e executa:
-- **Consultar** dados: retorna `true`/`false`.
-- **Inserir** dados: retorna `{ ok: true }`.
+API Express que executa fluxos do Playwright a partir de arquivos de **mapa**.
 
-Ideal para integração com n8n, cron jobs ou serviços internos.
+## Funcionalidades
 
----
+- Carrega automaticamente todos os arquivos em `src/mapas`.  
+  Cada mapa deve conter as chaves `operacao` e `categoria` para ser exposto pela API.
+- Disponibiliza endpoints REST para cada par `operacao/categoria` carregado.
 
-## 🔍 Descrição
+### Endpoints atuais
 
-O **Executor** faz:
+#### `GET /consultar/:categoria`
 
-1. **Carrega** automaticamente todos os arquivos `mapa_<operação>.json` em `src/mapas`.
-2. Para cada operação (`<nome>`):
-   - **GET  /<nome>**  
-     → chama `consultar({ url, loginInfo, dados, mapa })`  
-     → retorna `{ result: true|false }`.
-   - **POST /<nome>**  
-     → chama `inserir({ url, loginInfo, dados, mapa })`  
-     → retorna `{ ok: true }` ou erro 500.
+Executa o mapa de consulta e retorna se o resultado foi encontrado.
 
-Usuário ou orquestrador (ex.: n8n) envia JSON com:
-```jsonc
+Query params:
+
+- `url` – obrigatório.
+- Outros parâmetros definidos pelo mapa (ex.: `cpf`).
+
+Headers:
+
+- `login`
+- `password`
+
+Resposta: `{ "result": true | false }`
+
+#### `GET /baixar/:categoria`
+
+Executa o mapa de download.
+
+Query params:
+
+- `url` – obrigatório.
+- `dir` (opcional) – diretório onde salvar.
+- `filename` (opcional) – nome do arquivo.
+- Outros parâmetros definidos pelo mapa.
+
+Headers: `login`, `password`.
+
+Resposta: `{ "downloadedPath": "/caminho/do/arquivo" }`
+
+#### `POST /cadastrar/:categoria`
+
+Realiza cadastro conforme o mapa.
+
+Query params: `url` obrigatório.  
+Body: dados exigidos pelo mapa.  
+Headers: `login`, `password`.
+
+Resposta: `{ "ok": true }`
+
+#### `PATCH /editar/:categoria`
+
+Edita parcialmente um cadastro.
+
+Query params: `url` e/ou dados (podem aparecer na query ou no body).  
+Body: dados a atualizar.  
+Headers: `login`, `password`.
+
+Resposta: `{ "ok": true }`
+
+## Estrutura de mapa
+
+Exemplo simplificado de `src/mapas/exemplo.json`:
+
+```json
 {
-  "url": "https://…",
-  "loginInfo": { "usernameValue": "...", "passwordValue": "..." },
-  "dados": { /* key→valor conforme mapa */ }
+  "operacao": "consultar",
+  "categoria": "motorista",
+  "login": {
+    "username": "[name=\"formCad:nome\"]",
+    "password": "[name=\"formCad:senha\"]",
+    "submit": "[name=\"formCad:entrar\"]"
+  },
+  "steps": [
+    { "action": "fill", "selector": "...", "key": "cpf" }
+  ],
+  "logout": "#formMenu:j_idt10"
 }
+```
+
+As chaves utilizadas em ações `fill`, `upload` ou `select` determinam quais parâmetros são aceitos nas requisições.
+
+## Executando
+
+```bash
+npm install
+npm start
+```
+
+O servidor roda por padrão em `http://localhost:3001`.
+


### PR DESCRIPTION
## Summary
- descreve os novos endpoints (consultar, baixar, cadastrar, editar)
- documenta estrutura dos mapas e como executar o servidor

## Testing
- `npm test` *(falha: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6893a0aaef748327ab1cad6ab1efdc0d