### PR TITLE
fix: allow extra keys on cadastrar

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -68,10 +68,12 @@ function buildLoginInfo(req) {
   return { usernameValue, passwordValue };
 }
 
-function validateKeys(required, provided, { allowPartial = false } = {}) {
-  const invalid = provided.filter((k) => !required.includes(k));
-  if (invalid.length) {
-    throw new Error(`Chaves inválidas: ${invalid.join(', ')}`);
+function validateKeys(required, provided, { allowPartial = false, allowExtra = false } = {}) {
+  if (!allowExtra) {
+    const invalid = provided.filter((k) => !required.includes(k));
+    if (invalid.length) {
+      throw new Error(`Chaves inválidas: ${invalid.join(', ')}`);
+    }
   }
   if (!allowPartial) {
     const missing = required.filter((k) => !provided.includes(k));
@@ -170,7 +172,7 @@ app.post('/cadastrar/:categoria', async (req, res) => {
 
   const required = getStepKeys(mapa);
   const bodyKeys = Object.keys(req.body || {});
-  try { validateKeys(required, bodyKeys); } catch (e) {
+  try { validateKeys(required, bodyKeys, { allowExtra: true }); } catch (e) {
     return res.status(400).json({ error: e.message });
   }
 


### PR DESCRIPTION
## Summary
- tweak validation helper to optionally allow extra keys
- accept requests with extra fields on `POST /cadastrar`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6893ae522510832784e25e83eb09e0e3