### PR TITLE
Evita clique no selector de resultado

### DIFF
--- a/src/navegar.js
+++ b/src/navegar.js
@@ -227,12 +227,21 @@ async function runMapa({ url, loginInfo, dados = {}, mapa, options = {} }) {
             log('step:start', { i, action: step.action, selector: step.selector, key: step.key, meta });
 
             if (meta.resultSelector === true) {
-                // Apenas testa sua existência
+                // Apenas testa sua existência sem interagir com o elemento
                 try {
                     await loc.waitFor({ state: 'attached', timeout: resultWaitMs });
                     resultFound = true;
-                } catch { resultFound = false; }
-                break; // não executa mais nada antes do logout
+                }
+                catch {
+                    resultFound = false;
+                }
+
+                // Encerra imediatamente para evitar o clique do step
+                if (mapa.logout) {
+                    try { await robustClick({ selector: mapa.logout }); await quiet(); } catch { }
+                }
+                await closeAll();
+                return { resultFound, downloadedPath: (mapa.operacao === 'baixar') ? downloadedPath : null };
             }
 
             switch (action) {


### PR DESCRIPTION
## Summary
- stop executing steps after a result selector is found to avoid accidental clicks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b5575ddcc8327ad2492fe43164a0b