### PR TITLE
Handle multiple result selector steps

### DIFF
--- a/src/navegar.js
+++ b/src/navegar.js
@@ -227,11 +227,21 @@ async function runMapa({ url, loginInfo, dados = {}, mapa, options = {} }) {
             log('step:start', { i, action: step.action, selector: step.selector, key: step.key, meta });
 
             if (meta.resultSelector === true) {
-                // Apenas testa sua existência
-                try {
-                    await loc.waitFor({ state: 'attached', timeout: resultWaitMs });
-                    resultFound = true;
-                } catch { resultFound = false; }
+                // Testa este e os próximos passos marcados com resultSelector
+                for (let j = i; j < mapa.steps.length; j++) {
+                    const rsStep = mapa.steps[j];
+                    if (rsStep.meta?.resultSelector === true) {
+                        try {
+                            await page.locator(rsStep.selector).first().waitFor({ state: 'attached', timeout: resultWaitMs });
+                            resultFound = true;
+                            break;
+                        } catch {
+                            resultFound = false;
+                        }
+                    } else {
+                        break;
+                    }
+                }
                 break; // não executa mais nada antes do logout
             }
 


### PR DESCRIPTION
## Summary
- Support checking multiple `resultSelector` steps by iterating until a selector is found or none remain

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b821a16b483279d17112b8acfc484