### PR TITLE
Ensure logout occurs after timeout errors

### DIFF
--- a/src/navegar.js
+++ b/src/navegar.js
@@ -205,6 +205,7 @@ async function runMapa({ url, loginInfo, dados = {}, mapa, options = {} }) {
     };
 
     let resultFound = null;
+    let caughtError;
 
     try {
         await page.goto(url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
@@ -436,19 +437,18 @@ async function runMapa({ url, loginInfo, dados = {}, mapa, options = {} }) {
                     throw new Error(`Ação não suportada: ${action}`);
             }
         }
-
-        /* ---------- LOGOUT ---------- */
+    }
+    catch (err) {
+        caughtError = err;
+    }
+    finally {
         if (mapa.logout) {
             try { await robustClick({ selector: mapa.logout }); await quiet(); } catch { }
         }
-
         await closeAll();
-        return { resultFound, downloadedPath: (mapa.operacao === 'baixar') ? downloadedPath : null };
     }
-    catch (err) {
-        await closeAll();
-        throw err;
-    }
+    if (caughtError) throw caughtError;
+    return { resultFound, downloadedPath: (mapa.operacao === 'baixar') ? downloadedPath : null };
 }
 
 module.exports = { runMapa };


### PR DESCRIPTION
## Summary
- Always attempt logout and close browser context via `finally` block in `runMapa`
- Preserve the timeout error by rethrowing after logout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b994f437083279572729c962728c6